### PR TITLE
Fix issue where number types are not generated correctly and add test

### DIFF
--- a/typescript/generate.go
+++ b/typescript/generate.go
@@ -80,9 +80,9 @@ func TranslateReflectTypeString(reflectTypeString string) string {
 	switch reflectTypeString {
 	case "interface {}":
 		return "any"
-	case "int":
+	case "int", "int8", "int16", "int32", "int64":
 		return "number"
-	case "uint":
+	case "uint", "uint8", "uint16", "uint32", "uint64":
 		return "number"
 	case "bool":
 		return "boolean"

--- a/typescript/generate_test.go
+++ b/typescript/generate_test.go
@@ -14,6 +14,7 @@ type TestUser struct {
 	Admin     bool   `json:"admin,omitempty"`
 	Password  string `json:"-"`
 	Roles     []string
+	VoteCount uint64
 	CreatedAt time.Time
 	DeletedAt *time.Time
 	secret    string
@@ -67,6 +68,10 @@ func TestGenerate(t *testing.T) {
 						{
 							Name: "Roles",
 							Type: "string[]",
+						},
+						{
+							Name: "VoteCount",
+							Type: "number",
 						},
 						{
 							Name: "CreatedAt",


### PR DESCRIPTION
## Describe your changes
Currently, if the Golang struct contains an int or uint with a specified bit size, it will be created in the TS file as that specific type (rather than be convered to "number").

This change adds some additional cases to the switch statement, that will convert the Golang struct field correctly to "number". 

