### PR TITLE
Handle slices of numbers

### DIFF
--- a/typescript/generate.go
+++ b/typescript/generate.go
@@ -2,7 +2,6 @@ package typescript
 
 import (
 	"reflect"
-	"regexp"
 	"strings"
 )
 
@@ -79,25 +78,32 @@ func getTSFieldType(goFieldType string, tag jsonFieldTag) string {
 }
 
 func TranslateReflectTypeString(reflectTypeString string) string {
+	isSlice := strings.HasPrefix(reflectTypeString, "[]")
+	if isSlice {
+		reflectTypeString = strings.TrimPrefix(reflectTypeString, "[]")
+	}
+
+	tsType := translateReflectTypeString(reflectTypeString)
+	if isSlice {
+		tsType += "[]"
+	}
+
+	return tsType
+}
+
+func translateReflectTypeString(reflectTypeString string) string {
 	switch reflectTypeString {
 	case "interface {}":
 		return "any"
 	case "int", "int8", "int16", "int32", "int64":
 		return "number"
-	case "[]int", "[]int8", "[]int16", "[]int32", "[]int64":
-		return "number[]"
 	case "uint", "uint8", "uint16", "uint32", "uint64", "float", "float32", "float64":
 		return "number"
-	case "[]uint", "[]uint8", "[]uint16", "[]uint32", "[]uint64", "[]float", "[]float32", "[]float64":
-		return "number[]"
 	case "bool":
 		return "boolean"
 	case "time.Time":
 		return "string"
 	}
 
-	re := regexp.MustCompile(`(?m)^(\[\])?(\w+\.)?(\w+)$`)
-	x := re.FindStringSubmatch(reflectTypeString)
-
-	return x[3] + x[1]
+	return reflectTypeString
 }

--- a/typescript/generate.go
+++ b/typescript/generate.go
@@ -84,8 +84,12 @@ func TranslateReflectTypeString(reflectTypeString string) string {
 		return "any"
 	case "int", "int8", "int16", "int32", "int64":
 		return "number"
+	case "[]int", "[]int8", "[]int16", "[]int32", "[]int64":
+		return "number[]"
 	case "uint", "uint8", "uint16", "uint32", "uint64", "float", "float32", "float64":
 		return "number"
+	case "[]uint", "[]uint8", "[]uint16", "[]uint32", "[]uint64", "[]float", "[]float32", "[]float64":
+		return "number[]"
 	case "bool":
 		return "boolean"
 	case "time.Time":

--- a/typescript/generate_test.go
+++ b/typescript/generate_test.go
@@ -7,18 +7,19 @@ import (
 )
 
 type TestUser struct {
-	ID        uint   `json:"id"`
-	Name      string `json:"name"`
-	Age       int
-	Score     int    `json:"score,string"`
-	Admin     bool   `json:"admin,omitempty"`
-	Password  string `json:"-"`
-	Roles     []string
-	VoteCount uint64
-	CreatedAt time.Time
-	DeletedAt *time.Time
-	secret    string
-	Data      interface{}
+	ID          uint   `json:"id"`
+	Name        string `json:"name"`
+	Age         int
+	Score       int    `json:"score,string"`
+	Admin       bool   `json:"admin,omitempty"`
+	Password    string `json:"-"`
+	Roles       []string
+	VoteCount   uint64
+	CreatedAt   time.Time
+	DeletedAt   *time.Time
+	secret      string
+	Data        interface{}
+	NumberSlice []uint64 `json:"numberSlice,omitempty"`
 }
 
 func TestGenerate(t *testing.T) {
@@ -86,6 +87,11 @@ func TestGenerate(t *testing.T) {
 						{
 							Name: "Data",
 							Type: "any",
+						},
+						{
+							Name:     "numberSlice",
+							Type:     "number[]",
+							Optional: true,
 						},
 					},
 				},


### PR DESCRIPTION
Currently generate produces this when given this Go struct: 

Go Struct: 
```
type ZDUserUpdateDataPayload struct {
	ID                       uint64               `json:"id"`
	UserFields               []ZDUserFieldsUpdate `json:"user_fields,omitempty"`
	DefaultGroupMembershipID *uint64              `json:"defaultGroupMembershipID,omitempty"`
	GroupsToAdd              []uint64             `json:"groupsToAdd,omitempty"`
	GroupsToRemove           []uint64             `json:"groupsToRemove,omitempty"`
}
```

```
export interface ZDUserUpdateDataPayload {
	id: number
	user_fields?: ZDUserFieldsUpdate[] | null
	defaultGroupMembershipID?: number | null
	groupsToAdd?: uint64[] | null
	groupsToRemove?: uint64[] | null
}
```
