### PR TITLE
Fix custom structs naming

### DIFF
--- a/typescript/generate.go
+++ b/typescript/generate.go
@@ -103,6 +103,11 @@ func translateReflectTypeString(reflectTypeString string) string {
 		return "boolean"
 	case "time.Time":
 		return "string"
+	default:
+		// If not detected above, assume this is a custom struct. Trim the package name
+		if i := strings.LastIndex(reflectTypeString, "."); i >= 0 {
+			return reflectTypeString[i+1:]
+		}
 	}
 
 	return reflectTypeString

--- a/typescript/generate_test.go
+++ b/typescript/generate_test.go
@@ -6,25 +6,34 @@ import (
 	"time"
 )
 
+type TestCustomStruct struct {
+	ID            uint64 `json:"id"`
+	secret        string
+	AnotherSecret string    `json:"-"`
+	Slice         []float32 `json:"slice"`
+}
+
 type TestUser struct {
-	ID          uint   `json:"id"`
-	Name        string `json:"name"`
-	Age         int
-	Score       int    `json:"score,string"`
-	Admin       bool   `json:"admin,omitempty"`
-	Password    string `json:"-"`
-	Roles       []string
-	VoteCount   uint64
-	CreatedAt   time.Time
-	DeletedAt   *time.Time
-	secret      string
-	Data        interface{}
-	NumberSlice []uint64 `json:"numberSlice,omitempty"`
+	ID               uint   `json:"id"`
+	Name             string `json:"name"`
+	Age              int
+	Score            int    `json:"score,string"`
+	Admin            bool   `json:"admin,omitempty"`
+	Password         string `json:"-"`
+	Roles            []string
+	VoteCount        uint64
+	CreatedAt        time.Time
+	DeletedAt        *time.Time
+	secret           string
+	Data             interface{}
+	NumberSlice      []uint64 `json:"numberSlice,omitempty"`
+	TestCustomStruct TestCustomStruct
 }
 
 func TestGenerate(t *testing.T) {
 	// Unexported fields should not be used
 	_ = TestUser{}.secret
+	_ = TestUser{}.TestCustomStruct.secret
 
 	type args struct {
 		goStructs map[string]interface{}
@@ -92,6 +101,10 @@ func TestGenerate(t *testing.T) {
 							Name:     "numberSlice",
 							Type:     "number[]",
 							Optional: true,
+						},
+						{
+							Name: "TestCustomStruct",
+							Type: "TestCustomStruct",
 						},
 					},
 				},


### PR DESCRIPTION
Structs are being generated with their package name as a prefix - example:  

zendesk.CustomFieldOption  

This should be: CustomFieldOption.

The suggested fix lets the switch statement go through all possible options, then the default is to try and find a "." character in the string - if we do, we trim everything up to and including the ".", and return the remaining string.

If we do not find a "." in the string, we default back to just returning the original string.