### PR TITLE
Add ability to set Image CSP in forge

### DIFF
--- a/forge/csp.go
+++ b/forge/csp.go
@@ -8,6 +8,7 @@ import (
 type CSP struct {
 	Default []string
 	Script  []string
+	Image   []string
 	Connect []string
 	Frame   []string
 }
@@ -28,6 +29,10 @@ func (csp CSP) String() string {
 
 	if len(csp.Frame) > 0 {
 		result += fmt.Sprintf("frame-src %s;", strings.Join(csp.Frame, " "))
+	}
+
+	if len(csp.Image) > 0 {
+		result += fmt.Sprintf("image-src %s;", strings.Join(csp.Image, " "))
 	}
 
 	return result

--- a/forge/csp_test.go
+++ b/forge/csp_test.go
@@ -25,9 +25,13 @@ func TestCSPFull(t *testing.T) {
 			"'self'",
 			"example.com",
 		},
+		Image: []string{
+			"'self'",
+			"example.com",
+		},
 	}
 
-	expected := "default-src 'self' example.com;script-src 'self' example.com;connect-src 'self' example.com;frame-src 'self' example.com;"
+	expected := "default-src 'self' example.com;script-src 'self' example.com;connect-src 'self' example.com;frame-src 'self' example.com;image-src 'self' example.com;"
 	if err := forgetest.Assert(expected, csp.String()); err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
Allow users to specify image CSP in the forge package.

Currently, if trying to programmatically load images from an external site, you need to put the website into the "default" group. We should allow users to specify a list of websites to load images (and only images) from, for security.

This change adds that to the existing options, and also alters the unit test to account for this