### PR TITLE
Resolve issue with incorrect CSP Value

### DIFF
--- a/forge/csp.go
+++ b/forge/csp.go
@@ -32,7 +32,7 @@ func (csp CSP) String() string {
 	}
 
 	if len(csp.Image) > 0 {
-		result += fmt.Sprintf("image-src %s;", strings.Join(csp.Image, " "))
+		result += fmt.Sprintf("img-src %s;", strings.Join(csp.Image, " "))
 	}
 
 	return result

--- a/forge/csp_test.go
+++ b/forge/csp_test.go
@@ -31,7 +31,7 @@ func TestCSPFull(t *testing.T) {
 		},
 	}
 
-	expected := "default-src 'self' example.com;script-src 'self' example.com;connect-src 'self' example.com;frame-src 'self' example.com;image-src 'self' example.com;"
+	expected := "default-src 'self' example.com;script-src 'self' example.com;connect-src 'self' example.com;frame-src 'self' example.com;img-src 'self' example.com;"
 	if err := forgetest.Assert(expected, csp.String()); err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
In previous release, accidentally set the CSP directive as "image-src" when it should be "img-src". 

This resolves that issue. Apologies 